### PR TITLE
[Feature] 로그인 페이지 디자인 구현

### DIFF
--- a/apps/web/src/components/common/Button/Button.styled.ts
+++ b/apps/web/src/components/common/Button/Button.styled.ts
@@ -1,0 +1,20 @@
+import styled from "@emotion/styled";
+
+export const Button = styled.button<{ $width: string | number }>`
+  width: ${({ $width }) =>
+    typeof $width === "number" ? `${$width}px` : $width};
+  height: 40px;
+  padding: 0 16px;
+  border: 0;
+  border-radius: 10px;
+  background: #676767;
+  color: #fdfcfa;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  cursor: pointer;
+
+  &:hover {
+    background: #5d5d5d;
+  }
+`;

--- a/apps/web/src/components/common/Button/Button.tsx
+++ b/apps/web/src/components/common/Button/Button.tsx
@@ -1,0 +1,20 @@
+import type { ButtonHTMLAttributes, PropsWithChildren } from "react";
+import * as S from "./Button.styled";
+
+interface ButtonProps
+  extends PropsWithChildren, ButtonHTMLAttributes<HTMLButtonElement> {
+  width?: string | number;
+}
+
+export function Button({
+  children,
+  width = "100%",
+  type = "button",
+  ...buttonProps
+}: ButtonProps) {
+  return (
+    <S.Button type={type} $width={width} {...buttonProps}>
+      {children}
+    </S.Button>
+  );
+}

--- a/apps/web/src/components/common/Button/index.ts
+++ b/apps/web/src/components/common/Button/index.ts
@@ -1,1 +1,1 @@
-export { Button } from './Button';
+export { Button } from "./Button";

--- a/apps/web/src/components/common/Button/index.ts
+++ b/apps/web/src/components/common/Button/index.ts
@@ -1,0 +1,1 @@
+export { Button } from './Button';

--- a/apps/web/src/components/common/CheckboxField/CheckboxField.styled.ts
+++ b/apps/web/src/components/common/CheckboxField/CheckboxField.styled.ts
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+
+export const Label = styled.label`
+  display: inline-flex;
+  align-items: center;
+  gap: 3.5px;
+  color: #6b6b6b;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  cursor: pointer;
+`;
+
+export const Checkbox = styled.input`
+  width: 13px;
+  height: 13px;
+  margin: 0;
+  accent-color: #676767;
+`;

--- a/apps/web/src/components/common/CheckboxField/CheckboxField.tsx
+++ b/apps/web/src/components/common/CheckboxField/CheckboxField.tsx
@@ -1,0 +1,19 @@
+import type { InputHTMLAttributes } from "react";
+import * as S from "./CheckboxField.styled";
+
+interface CheckboxFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+}
+
+export function CheckboxField({
+  label,
+  type = "checkbox",
+  ...inputProps
+}: CheckboxFieldProps) {
+  return (
+    <S.Label>
+      <S.Checkbox type={type} {...inputProps} />
+      <span>{label}</span>
+    </S.Label>
+  );
+}

--- a/apps/web/src/components/common/CheckboxField/index.ts
+++ b/apps/web/src/components/common/CheckboxField/index.ts
@@ -1,0 +1,1 @@
+export { CheckboxField } from './CheckboxField';

--- a/apps/web/src/components/common/CheckboxField/index.ts
+++ b/apps/web/src/components/common/CheckboxField/index.ts
@@ -1,1 +1,1 @@
-export { CheckboxField } from './CheckboxField';
+export { CheckboxField } from "./CheckboxField";

--- a/apps/web/src/components/common/InputField/InputField.styled.ts
+++ b/apps/web/src/components/common/InputField/InputField.styled.ts
@@ -1,0 +1,35 @@
+import styled from "@emotion/styled";
+
+export const Field = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const Label = styled.label`
+  color: #1a1a1a;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 14px;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  height: 36px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: #c6c6c6;
+  color: #1a1a1a;
+  font-size: 14px;
+
+  &::placeholder {
+    color: rgba(26, 26, 26, 0.48);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: rgba(26, 26, 26, 0.25);
+    background: #d1d1d1;
+  }
+`;

--- a/apps/web/src/components/common/InputField/InputField.tsx
+++ b/apps/web/src/components/common/InputField/InputField.tsx
@@ -1,0 +1,21 @@
+import type { InputHTMLAttributes } from "react";
+import * as S from "./InputField.styled";
+
+interface InputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  id: string;
+  label: string;
+}
+
+export function InputField({
+  id,
+  label,
+  type = "text",
+  ...inputProps
+}: InputFieldProps) {
+  return (
+    <S.Field>
+      <S.Label htmlFor={id}>{label}</S.Label>
+      <S.Input id={id} type={type} {...inputProps} />
+    </S.Field>
+  );
+}

--- a/apps/web/src/components/common/InputField/index.ts
+++ b/apps/web/src/components/common/InputField/index.ts
@@ -1,0 +1,1 @@
+export { InputField } from "./InputField";

--- a/apps/web/src/components/common/TextButton/TextButton.styled.ts
+++ b/apps/web/src/components/common/TextButton/TextButton.styled.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+export const TextButton = styled.a<{ $fontWeight: 400 | 500 }>`
+  color: #000;
+  font-size: 14px;
+  font-weight: ${({ $fontWeight }) => $fontWeight};
+  line-height: 20px;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;

--- a/apps/web/src/components/common/TextButton/TextButton.tsx
+++ b/apps/web/src/components/common/TextButton/TextButton.tsx
@@ -1,0 +1,19 @@
+import type { AnchorHTMLAttributes, PropsWithChildren } from "react";
+import * as S from "./TextButton.styled";
+
+interface TextButtonProps
+  extends PropsWithChildren, AnchorHTMLAttributes<HTMLAnchorElement> {
+  fontWeight?: 400 | 500;
+}
+
+export function TextButton({
+  children,
+  fontWeight = 500,
+  ...anchorProps
+}: TextButtonProps) {
+  return (
+    <S.TextButton $fontWeight={fontWeight} {...anchorProps}>
+      {children}
+    </S.TextButton>
+  );
+}

--- a/apps/web/src/components/common/TextButton/index.ts
+++ b/apps/web/src/components/common/TextButton/index.ts
@@ -1,0 +1,1 @@
+export { TextButton } from './TextButton';

--- a/apps/web/src/components/common/TextButton/index.ts
+++ b/apps/web/src/components/common/TextButton/index.ts
@@ -1,1 +1,1 @@
-export { TextButton } from './TextButton';
+export { TextButton } from "./TextButton";

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,1 +1,5 @@
+export * from "./Button";
+export * from "./CheckboxField";
+export * from "./InputField";
 export * from "./Layout";
+export * from "./TextButton";

--- a/apps/web/src/pages/LoginPage/LoginPage.styled.ts
+++ b/apps/web/src/pages/LoginPage/LoginPage.styled.ts
@@ -1,5 +1,78 @@
 import styled from "@emotion/styled";
 
 export const Page = styled.div`
-  padding: 2rem;
+  position: relative;
+  min-height: calc(100vh - 65px);
+  overflow: hidden;
+  background: ${({ theme }) => theme.gray[100]};
+`;
+
+export const SplitBackground = styled.div`
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+`;
+
+export const LeftBackground = styled.div`
+  background: #efefef;
+`;
+
+export const RightBackground = styled.div`
+  background: #767676;
+`;
+
+export const Content = styled.div`
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
+  width: 100%;
+  min-height: calc(100vh - 140px);
+  padding: 80px 0;
+`;
+
+export const FormSection = styled.section`
+  width: 100%;
+  max-width: 448px;
+  padding-top: 8px;
+  justify-self: center;
+`;
+
+export const WelcomeTitle = styled.h1`
+  margin: 0;
+  color: #1a1a1a;
+  font-size: 30px;
+  font-weight: 700;
+  line-height: 36px;
+`;
+
+export const WelcomeDescription = styled.p`
+  margin: 8px 0 0;
+  color: #6b6b6b;
+  font-size: 16px;
+  line-height: 24px;
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-top: 32px;
+`;
+
+export const OptionsRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+`;
+
+export const SignupText = styled.p`
+  margin: 28px 0 0;
+  color: #6b6b6b;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: center;
 `;

--- a/apps/web/src/pages/LoginPage/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage/LoginPage.tsx
@@ -1,10 +1,52 @@
+import {
+  Button,
+  CheckboxField,
+  InputField,
+  TextButton,
+} from "@/components/common";
 import * as S from "./LoginPage.styled";
 
 export function LoginPage() {
   return (
     <S.Page>
-      <h1>로그인</h1>
-      <p>계정에 로그인합니다.</p>
+      <S.SplitBackground aria-hidden="true">
+        <S.LeftBackground />
+        <S.RightBackground />
+      </S.SplitBackground>
+
+      <S.Content>
+        <S.FormSection>
+          <S.WelcomeTitle>다시 만나서 반가워요</S.WelcomeTitle>
+          <S.WelcomeDescription>
+            정원에 물을 주러 오셨군요!
+          </S.WelcomeDescription>
+
+          <S.Form>
+            <InputField id="email" name="email" type="email" label="이메일" />
+
+            <InputField
+              id="password"
+              name="password"
+              type="password"
+              label="비밀번호"
+            />
+
+            <S.OptionsRow>
+              <CheckboxField label="로그인 상태 유지" name="remember" />
+
+              <TextButton href="#" fontWeight={400}>
+                비밀번호 찾기
+              </TextButton>
+            </S.OptionsRow>
+
+            <Button type="submit">로그인</Button>
+          </S.Form>
+
+          <S.SignupText>
+            아직 정원이 없으신가요? <TextButton href="#">회원가입</TextButton>
+          </S.SignupText>
+        </S.FormSection>
+      </S.Content>
     </S.Page>
   );
 }

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -1,7 +1,11 @@
 {
   "extends": "@jandi-fe/typescript-config/react-vite-app",
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export default defineConfig({
   plugins: [react()],

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
 });

--- a/packages/ui/src/GlobalStyles.tsx
+++ b/packages/ui/src/GlobalStyles.tsx
@@ -32,8 +32,7 @@ const globalStyles = css`
 
   body {
     margin: 0;
-    display: flex;
-    place-items: center;
+    width: 100%;
     min-width: 320px;
     min-height: 100vh;
   }


### PR DESCRIPTION
# Pull requests

## 작업 내용
공통 컴포넌트들을 구현했습니다.

Button : 로그인 버튼 등 전반적으로 사용되는 버튼 컴포넌트입니다. 
- width 파라미터에 number 또는 string 값을 입력으로 받습니다. number 입력시 자동으로 px로 적용, string 입력시 %나 auto 등의 값을 입력하면 됩니다. 
- 기본 값으로는 100%가 적용됩니다.

InputField : 레이블과 input을 함께 묶어둔 컴포넌트입니다.
- id, label, type 값을 입력으로 받습니다. 
- 기본 값으로는 text 타입을 지정해뒀습니다.

CheckboxField : 레이블과 체크박스를 함께 묶어둔 컴포넌트입니다.
- label 값을 입력으로 받습니다.
- 사용하는 곳이 거의 없을 것 같긴 한데, 우선은 구현해 두었습니다.

TextButton : 텍스트 형식의 버튼 컴포넌트입니다. (<a> 태그와 동일)
- fontWeight 값을 입력으로 받습니다. 지금으로썬 400 또는 500 값만 받을 수 있도록 했습니다. 추후 디자인 따라서 추가하면 될 것 같습니다.
- 기본 값으로는 500이 적용됩니다.

로그인 페이지를 구현했습니다.
- 상단 Jandi 로고 부분은 헤더에 포함되어야 하는 것 같아서 일단은 제외했습니다.
- 우측 오늘 한 칸 심기 카드 부분도 디자인 확정이 되지 않아 일단 제외했습니다.

## 참고 사항
아직 와이어프레임 단계라서 컴포넌트 위주로 작업했습니다. 

컴포넌트 import에서 사용할 수 있도록 path alias를 설정했습니다.

문법이나 스타일 등 이상하거나 잘못 작성한 부분이 있으면 편하게 알려주시면 감사하겠습니다. 

## 화면 구성
<img width="2559" height="1305" alt="image" src="https://github.com/user-attachments/assets/f675dfe5-727d-4a04-a48e-bc41b2ebe92d" />

## Check List

- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 영향을 주지 않음
- [x] 린트/포맷팅 적용 완료
- [ ] 관련 테스트 작성 또는 기존 테스트 통과 확인
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 포함됨

## 이슈

- close #2 
