### PR TITLE
[Feat] my garden page ui

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,10 +2,6 @@ import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
 
 function App() {
-  // TODO: ErrorBoundary 테스트 후 제거
-  if (import.meta.env.DEV && window.location.search.includes("?error=1")) {
-    throw new Error("ErrorBoundary 테스트용 에러");
-  }
   return <RouterProvider router={router} />;
 }
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,10 @@ import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
 
 function App() {
+  // TODO: ErrorBoundary 테스트 후 제거
+  if (import.meta.env.DEV && window.location.search.includes("?error=1")) {
+    throw new Error("ErrorBoundary 테스트용 에러");
+  }
   return <RouterProvider router={router} />;
 }
 

--- a/apps/web/src/components/common/ErrorBoundary/ErrorBoundary.styled.ts
+++ b/apps/web/src/components/common/ErrorBoundary/ErrorBoundary.styled.ts
@@ -1,0 +1,111 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+  background: ${({ theme }) => theme.gray[50]};
+`;
+
+export const Card = styled.div`
+  max-width: 400px;
+  padding: 2rem;
+  border-radius: 12px;
+  background: white;
+  border: 1px solid ${({ theme }) => theme.gray[200]};
+  text-align: center;
+`;
+
+export const IconWrapper = styled.div<{
+  $variant: "ClientError" | "ServerError" | "NetworkError" | "Error";
+}>`
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 1rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  background: ${({ theme, $variant }) =>
+    $variant === "ClientError"
+      ? theme.gray[200]
+      : $variant === "NetworkError"
+        ? "#fef3c7"
+        : $variant === "ServerError"
+          ? "#fee2e2"
+          : theme.gray[300]};
+  color: ${({ theme, $variant }) =>
+    $variant === "ClientError"
+      ? theme.gray[600]
+      : $variant === "NetworkError"
+        ? "#b45309"
+        : $variant === "ServerError"
+          ? "#dc2626"
+          : theme.gray[700]};
+`;
+
+export const Message = styled.p`
+  margin: 0 0 1.5rem;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1.5;
+  color: ${({ theme }) => theme.gray[800]};
+`;
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+`;
+
+export const StyledButton = styled.button`
+  padding: 0.5rem 1rem;
+  border: 0;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;
+
+export const PrimaryButton = styled(StyledButton)`
+  background: ${({ theme }) => theme.gray[700]};
+  color: white;
+`;
+
+export const SecondaryButton = styled(StyledButton)`
+  background: ${({ theme }) => theme.gray[200]};
+  color: ${({ theme }) => theme.gray[800]};
+`;
+
+export const DebugSection = styled.details`
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid ${({ theme }) => theme.gray[200]};
+  text-align: left;
+
+  & summary {
+    font-size: 12px;
+    color: ${({ theme }) => theme.gray[500]};
+    cursor: pointer;
+    margin-bottom: 0.5rem;
+  }
+
+  & pre {
+    margin: 0;
+    font-size: 11px;
+    font-family: monospace;
+    white-space: pre-wrap;
+    word-break: break-all;
+    color: ${({ theme }) => theme.gray[600]};
+  }
+`;

--- a/apps/web/src/components/common/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/web/src/components/common/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,91 @@
+import { Component, type ReactNode } from "react";
+import { ClientError, NetworkError, ServerError } from "@jandi-fe/api";
+import * as S from "./ErrorBoundary.styled";
+
+type ErrorVariant = "ClientError" | "ServerError" | "NetworkError" | "Error";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+}
+
+const ERROR_ICONS: Record<ErrorVariant, string> = {
+  ClientError: "📄",
+  ServerError: "⚠️",
+  NetworkError: "📡",
+  Error: "❌",
+};
+
+function getErrorVariant(error: Error): ErrorVariant {
+  if (error instanceof ClientError) return "ClientError";
+  if (error instanceof ServerError) return "ServerError";
+  if (error instanceof NetworkError) return "NetworkError";
+  return "Error";
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, errorInfo);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: undefined });
+  };
+
+  handleGoHome = () => {
+    window.location.href = "/";
+  };
+
+  renderFallback() {
+    const { error } = this.state;
+    if (!error) return null;
+
+    const variant = getErrorVariant(error);
+    const isDev = import.meta.env.DEV;
+
+    return (
+      <S.Container>
+        <S.Card>
+          <S.IconWrapper $variant={variant}>
+            {ERROR_ICONS[variant]}
+          </S.IconWrapper>
+          <S.Message>{error.message}</S.Message>
+          <S.ButtonGroup>
+            <S.PrimaryButton type="button" onClick={this.handleReset}>
+              다시 시도
+            </S.PrimaryButton>
+            <S.SecondaryButton type="button" onClick={this.handleGoHome}>
+              홈으로
+            </S.SecondaryButton>
+          </S.ButtonGroup>
+          {(isDev || error.stack) && (
+            <S.DebugSection open={isDev}>
+              <summary>상세 정보</summary>
+              <pre>{error.stack ?? error.message}</pre>
+            </S.DebugSection>
+          )}
+        </S.Card>
+      </S.Container>
+    );
+  }
+
+  render() {
+    if (this.state.hasError && this.state.error) {
+      return this.renderFallback();
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/src/components/common/ErrorBoundary/ErrorBoundary.tsx
+++ b/apps/web/src/components/common/ErrorBoundary/ErrorBoundary.tsx
@@ -71,8 +71,8 @@ export class ErrorBoundary extends Component<Props, State> {
               홈으로
             </S.SecondaryButton>
           </S.ButtonGroup>
-          {(isDev || error.stack) && (
-            <S.DebugSection open={isDev}>
+          {isDev && (
+            <S.DebugSection open>
               <summary>상세 정보</summary>
               <pre>{error.stack ?? error.message}</pre>
             </S.DebugSection>

--- a/apps/web/src/components/common/Header/Header.constants.ts
+++ b/apps/web/src/components/common/Header/Header.constants.ts
@@ -1,0 +1,6 @@
+export const NAV_ITEMS = [
+  { name: "나의 정원", path: "/" },
+  { name: "위젯", path: "/widget" },
+  { name: "설정", path: "/settings" },
+  { name: "계정관리", path: "/account" },
+] as const;

--- a/apps/web/src/components/common/Header/Header.styled.ts
+++ b/apps/web/src/components/common/Header/Header.styled.ts
@@ -1,0 +1,85 @@
+import styled from "@emotion/styled";
+import { Link } from "react-router-dom";
+
+export const Header = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid ${({ theme }) => theme.gray[200]};
+`;
+
+export const LogoLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: inherit;
+  text-decoration: none;
+  font-weight: ${({ theme }) => theme.fonts.weight.semibold};
+  font-size: ${({ theme }) => theme.fonts.size.xl};
+`;
+
+export const LogoIcon = styled.span`
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: ${({ theme }) => theme.gray[400]};
+`;
+
+export const Nav = styled.nav`
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+`;
+
+export const NavList = styled.ul`
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+export const NavLink = styled(Link)<{ $active?: boolean }>`
+  color: inherit;
+  text-decoration: none;
+  font-weight: ${({ theme, $active }) =>
+    $active ? theme.fonts.weight.semibold : theme.fonts.weight.normal};
+  opacity: ${({ $active }) => ($active ? 1 : 0.8)};
+  font-size: ${({ theme }) => theme.fonts.size.sm};
+
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+export const AuthButton = styled.button`
+  padding: 0.5rem 1rem;
+  border: 1px solid ${({ theme }) => theme.gray[300]};
+  border-radius: 9999px;
+  background: transparent;
+  font-size: ${({ theme }) => theme.fonts.size.sm};
+  font-weight: ${({ theme }) => theme.fonts.weight.medium};
+  cursor: pointer;
+  color: inherit;
+
+  &:hover {
+    background: ${({ theme }) => theme.gray[100]};
+  }
+`;
+
+export const LoginLink = styled(Link)`
+  padding: 0.5rem 1rem;
+  border: 1px solid ${({ theme }) => theme.gray[300]};
+  border-radius: 9999px;
+  background: transparent;
+  font-size: ${({ theme }) => theme.fonts.size.sm};
+  font-weight: ${({ theme }) => theme.fonts.weight.medium};
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    background: ${({ theme }) => theme.gray[100]};
+  }
+`;

--- a/apps/web/src/components/common/Header/Header.tsx
+++ b/apps/web/src/components/common/Header/Header.tsx
@@ -1,0 +1,38 @@
+import { useLocation } from "react-router-dom";
+import { useAuthStore } from "@/stores/authStore";
+import { NAV_ITEMS } from "./Header.constants";
+import * as S from "./Header.styled";
+
+export function Header() {
+  const location = useLocation();
+  const { isLoggedIn, logout } = useAuthStore();
+
+  return (
+    <S.Header>
+      <S.LogoLink to="/">
+        {/* TODO:실제 로고 이미지로 변경 필요 */}
+        <S.LogoIcon />
+        Jandi
+      </S.LogoLink>
+      <S.Nav>
+        {/* 네비게이션 리스트로 목록 관리*/}
+        <S.NavList>
+          {NAV_ITEMS.map(({ name, path }) => (
+            <li key={path}>
+              <S.NavLink to={path} $active={location.pathname === path}>
+                {name}
+              </S.NavLink>
+            </li>
+          ))}
+        </S.NavList>
+        {isLoggedIn ? (
+          <S.AuthButton type="button" onClick={logout}>
+            로그아웃
+          </S.AuthButton>
+        ) : (
+          <S.LoginLink to="/login">로그인</S.LoginLink>
+        )}
+      </S.Nav>
+    </S.Header>
+  );
+}

--- a/apps/web/src/components/common/Header/index.ts
+++ b/apps/web/src/components/common/Header/index.ts
@@ -1,0 +1,1 @@
+export * from "./Header";

--- a/apps/web/src/components/common/Layout/Layout.styled.ts
+++ b/apps/web/src/components/common/Layout/Layout.styled.ts
@@ -1,34 +1,9 @@
 import styled from "@emotion/styled";
-import { Link } from "react-router-dom";
 
 export const Container = styled.div`
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-`;
-
-export const Nav = styled.nav`
-  padding: 1rem 2rem;
-  border-bottom: 1px solid ${({ theme }) => theme.gray[200]};
-`;
-
-export const NavList = styled.ul`
-  display: flex;
-  gap: 1.5rem;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-`;
-
-export const NavLink = styled(Link)<{ $active?: boolean }>`
-  color: inherit;
-  text-decoration: none;
-  font-weight: ${({ $active }) => ($active ? 600 : 400)};
-  opacity: ${({ $active }) => ($active ? 1 : 0.8)};
-
-  &:hover {
-    opacity: 1;
-  }
 `;
 
 export const Main = styled.main`

--- a/apps/web/src/components/common/Layout/Layout.tsx
+++ b/apps/web/src/components/common/Layout/Layout.tsx
@@ -1,48 +1,11 @@
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet } from "react-router-dom";
+import { Header } from "../Header";
 import * as S from "./Layout.styled";
 
 export function Layout() {
-  const location = useLocation();
-
   return (
     <S.Container>
-      <S.Nav>
-        <S.NavList>
-          <li>
-            <S.NavLink to="/" $active={location.pathname === "/"}>
-              나의 정원
-            </S.NavLink>
-          </li>
-          <li>
-            <S.NavLink to="/widget" $active={location.pathname === "/widget"}>
-              위젯
-            </S.NavLink>
-          </li>
-          <li>
-            <S.NavLink
-              to="/settings"
-              $active={location.pathname === "/settings"}
-            >
-              설정
-            </S.NavLink>
-          </li>
-          <li>
-            <S.NavLink to="/account" $active={location.pathname === "/account"}>
-              계정관리
-            </S.NavLink>
-          </li>
-          <li>
-            <S.NavLink to="/login" $active={location.pathname === "/login"}>
-              로그인
-            </S.NavLink>
-          </li>
-          <li>
-            <S.NavLink to="/signup" $active={location.pathname === "/signup"}>
-              회원가입
-            </S.NavLink>
-          </li>
-        </S.NavList>
-      </S.Nav>
+      <Header />
       <S.Main>
         <Outlet />
       </S.Main>

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,4 +1,5 @@
 export * from "./Button";
+export * from "./Header";
 export * from "./CheckboxField";
 export * from "./InputField";
 export * from "./Layout";

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,16 +3,19 @@ import { createRoot } from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "@emotion/react";
 import { GlobalStyles, theme } from "@jandi-fe/ui";
+import { ErrorBoundary } from "./components/common/ErrorBoundary/ErrorBoundary";
 import { queryClient } from "./lib/queryClient";
 import App from "./App.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <GlobalStyles />
-        <App />
-      </ThemeProvider>
-    </QueryClientProvider>
+    <ThemeProvider theme={theme}>
+      <ErrorBoundary>
+        <QueryClientProvider client={queryClient}>
+          <GlobalStyles />
+          <App />
+        </QueryClientProvider>
+      </ErrorBoundary>
+    </ThemeProvider>
   </StrictMode>
 );

--- a/apps/web/src/pages/AccountPage/index.ts
+++ b/apps/web/src/pages/AccountPage/index.ts
@@ -1,1 +1,1 @@
-export { AccountPage } from "./AccountPage";
+export * from "./AccountPage";

--- a/apps/web/src/pages/LoginPage/index.ts
+++ b/apps/web/src/pages/LoginPage/index.ts
@@ -1,1 +1,1 @@
-export { LoginPage } from "./LoginPage";
+export * from "./LoginPage";

--- a/apps/web/src/pages/MyGardenPage/MyGardenPage.constants.ts
+++ b/apps/web/src/pages/MyGardenPage/MyGardenPage.constants.ts
@@ -1,0 +1,12 @@
+/** 임의 카테고리 색상 */
+export const DEFAULT_CATEGORY_COLORS: Record<string, string> = {
+  AI: "#64748b",
+  Cloud: "#94a3b8",
+  Backend: "#818cf8",
+  Frontend: "#a78bfa",
+  DevOps: "#f472b6",
+  기타: "#cbd5e1",
+};
+
+/** 카테고리 색상 배열 */
+export const CATEGORY_COLORS = Object.values(DEFAULT_CATEGORY_COLORS);

--- a/apps/web/src/pages/MyGardenPage/MyGardenPage.mocks.ts
+++ b/apps/web/src/pages/MyGardenPage/MyGardenPage.mocks.ts
@@ -23,27 +23,6 @@ export interface MyGardenPageData {
   jandi_data: JandiItem[];
 }
 
-export interface DateDetailItem {
-  date: string;
-  post_count: number;
-  category: string;
-}
-
-export interface DateDetailPost {
-  id: string;
-  title: string;
-  url?: string;
-  category: string;
-  date: string;
-}
-
-export interface DateDetailResponse {
-  period: JandiPeriod;
-  date: string;
-  jandi_data: DateDetailItem[];
-  posts: DateDetailPost[];
-}
-
 export const MOCK_MY_GARDEN_PAGE: MyGardenPageData = {
   user_summary: {
     total_posts: 28,

--- a/apps/web/src/pages/MyGardenPage/MyGardenPage.mocks.ts
+++ b/apps/web/src/pages/MyGardenPage/MyGardenPage.mocks.ts
@@ -1,0 +1,89 @@
+export interface UserSummary {
+  total_posts: number;
+  total_active_days: number;
+  current_streak: number;
+  max_streak: number;
+  color_theme: string;
+}
+
+export interface JandiItem {
+  date: string;
+  post_count: number;
+  category: string;
+}
+
+export interface JandiPeriod {
+  start: string;
+  end: string;
+}
+
+export interface MyGardenPageData {
+  user_summary: UserSummary;
+  period: JandiPeriod;
+  jandi_data: JandiItem[];
+}
+
+export interface DateDetailItem {
+  date: string;
+  post_count: number;
+  category: string;
+}
+
+export interface DateDetailPost {
+  id: string;
+  title: string;
+  url?: string;
+  category: string;
+  date: string;
+}
+
+export interface DateDetailResponse {
+  period: JandiPeriod;
+  date: string;
+  jandi_data: DateDetailItem[];
+  posts: DateDetailPost[];
+}
+
+export const MOCK_MY_GARDEN_PAGE: MyGardenPageData = {
+  user_summary: {
+    total_posts: 28,
+    total_active_days: 28,
+    current_streak: 15,
+    max_streak: 23,
+    color_theme: "#64748b",
+  },
+  period: {
+    start: "2026-01-01",
+    end: "2026-03-31",
+  },
+  jandi_data: [
+    { date: "2026-01-01", post_count: 1, category: "AI" },
+    { date: "2026-01-04", post_count: 1, category: "Backend" },
+    { date: "2026-01-06", post_count: 1, category: "DevOps" },
+    { date: "2026-01-09", post_count: 1, category: "Cloud" },
+    { date: "2026-01-12", post_count: 1, category: "Frontend" },
+    { date: "2026-01-14", post_count: 1, category: "AI" },
+    { date: "2026-01-17", post_count: 1, category: "Backend" },
+    { date: "2026-01-20", post_count: 1, category: "Frontend" },
+    { date: "2026-01-22", post_count: 1, category: "AI" },
+    { date: "2026-01-25", post_count: 1, category: "Backend" },
+    { date: "2026-01-28", post_count: 1, category: "기타" },
+    { date: "2026-01-31", post_count: 1, category: "Cloud" },
+    { date: "2026-02-01", post_count: 1, category: "Backend" },
+    { date: "2026-02-04", post_count: 1, category: "Frontend" },
+    { date: "2026-02-07", post_count: 1, category: "AI" },
+    { date: "2026-02-10", post_count: 1, category: "DevOps" },
+    { date: "2026-02-13", post_count: 1, category: "Cloud" },
+    { date: "2026-02-16", post_count: 1, category: "Backend" },
+    { date: "2026-02-19", post_count: 1, category: "Frontend" },
+    { date: "2026-02-22", post_count: 1, category: "AI" },
+    { date: "2026-02-25", post_count: 1, category: "기타" },
+    { date: "2026-02-28", post_count: 1, category: "Cloud" },
+    { date: "2026-03-03", post_count: 1, category: "AI" },
+    { date: "2026-03-08", post_count: 1, category: "Backend" },
+    { date: "2026-03-12", post_count: 1, category: "Frontend" },
+    { date: "2026-03-15", post_count: 1, category: "DevOps" },
+    { date: "2026-03-20", post_count: 1, category: "Cloud" },
+    { date: "2026-03-25", post_count: 1, category: "기타" },
+  ],
+};

--- a/apps/web/src/pages/MyGardenPage/MyGardenPage.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/MyGardenPage.styled.ts
@@ -2,4 +2,45 @@ import styled from "@emotion/styled";
 
 export const Page = styled.div`
   padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+`;
+
+export const Header = styled.header`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+`;
+
+export const TitleGroup = styled.div`
+  flex: 1;
+`;
+
+export const Title = styled.h1`
+  margin: 0 0 0.25rem 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+`;
+
+export const Subtitle = styled.p`
+  margin: 0;
+  font-size: 0.875rem;
+  color: ${({ theme }) => theme.gray[500]};
+`;
+
+export const BottomSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+export const BottomRow = styled.div`
+  display: flex;
+  gap: 1.5rem;
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+  }
 `;

--- a/apps/web/src/pages/MyGardenPage/MyGardenPage.tsx
+++ b/apps/web/src/pages/MyGardenPage/MyGardenPage.tsx
@@ -1,10 +1,50 @@
+import { useState } from "react";
+import {
+  CategoryRatio,
+  GardenGraph,
+  RecentPosts,
+  SummaryCards,
+} from "./components";
+import { MOCK_MY_GARDEN_PAGE } from "./MyGardenPage.mocks";
 import * as S from "./MyGardenPage.styled";
+import { useGardenGraph } from "./components/GardenGraph/useGardenGraph";
 
 export function MyGardenPage() {
+  const [year, setYear] = useState(new Date().getFullYear());
+  const [month, setMonth] = useState(new Date().getMonth() + 1);
+
+  const { user_summary, jandi_data, period } = MOCK_MY_GARDEN_PAGE;
+
+  const gardenGraph = useGardenGraph({
+    year,
+    month,
+    jandiData: jandi_data,
+    period,
+  });
+
   return (
     <S.Page>
-      <h1>나의 정원</h1>
-      <p>블로그 활동을 잔디처럼 시각화한 공간입니다.</p>
+      <S.Header>
+        <S.TitleGroup>
+          <S.Title>나의 정원</S.Title>
+          <S.Subtitle>블로그 활동을 한눈에 확인하세요</S.Subtitle>
+        </S.TitleGroup>
+      </S.Header>
+      <SummaryCards userSummary={user_summary} />
+      <GardenGraph
+        key={`${year}-${month}`}
+        year={year}
+        month={month}
+        onYearChange={setYear}
+        onMonthChange={setMonth}
+        {...gardenGraph}
+      />
+      <S.BottomSection>
+        <S.BottomRow>
+          <CategoryRatio />
+          <RecentPosts />
+        </S.BottomRow>
+      </S.BottomSection>
     </S.Page>
   );
 }

--- a/apps/web/src/pages/MyGardenPage/components/CategoryRatio/CategoryRatio.mocks.ts
+++ b/apps/web/src/pages/MyGardenPage/components/CategoryRatio/CategoryRatio.mocks.ts
@@ -1,0 +1,22 @@
+export interface TopicRatio {
+  category: string;
+  count: number;
+  percentage: number;
+}
+
+export interface CategoryRatioResponse {
+  total_posts: number;
+  global_topic_ratios: TopicRatio[];
+}
+
+export const MOCK_CATEGORY_RATIO: CategoryRatioResponse = {
+  total_posts: 28,
+  global_topic_ratios: [
+    { category: "AI", count: 8, percentage: 28.6 },
+    { category: "Cloud", count: 6, percentage: 21.4 },
+    { category: "Backend", count: 5, percentage: 17.9 },
+    { category: "Frontend", count: 4, percentage: 14.3 },
+    { category: "DevOps", count: 3, percentage: 10.7 },
+    { category: "기타", count: 2, percentage: 7.1 },
+  ],
+};

--- a/apps/web/src/pages/MyGardenPage/components/CategoryRatio/CategoryRatio.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/CategoryRatio/CategoryRatio.styled.ts
@@ -1,0 +1,46 @@
+import styled from "@emotion/styled";
+
+export const ChartPlaceholder = styled.div`
+  width: 100%;
+  min-height: 120px;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+`;
+
+export const ChartBarContainer = styled.div`
+  display: flex;
+  height: 100%;
+  min-height: 100px;
+  border-radius: 6px;
+  overflow: hidden;
+`;
+
+export const ChartBar = styled.div<{ $width: number; $color: string }>`
+  flex: ${({ $width }) => $width} 1 0;
+  min-width: 4px;
+  background: ${({ $color }) => $color};
+`;
+
+export const CategoryList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const CategoryItem = styled.li`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+`;
+
+export const CategoryDot = styled.span<{ $color: string }>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${({ $color }) => $color};
+`;

--- a/apps/web/src/pages/MyGardenPage/components/CategoryRatio/CategoryRatio.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/CategoryRatio/CategoryRatio.tsx
@@ -1,0 +1,52 @@
+import {
+  CATEGORY_COLORS,
+  DEFAULT_CATEGORY_COLORS,
+} from "../../MyGardenPage.constants";
+import { SectionCard } from "../SectionCard";
+import type { CategoryRatioResponse } from "./CategoryRatio.mocks";
+import { MOCK_CATEGORY_RATIO } from "./CategoryRatio.mocks";
+import * as S from "./CategoryRatio.styled";
+
+interface CategoryRatioProps {
+  data?: CategoryRatioResponse | null;
+}
+
+export function CategoryRatio({
+  data = MOCK_CATEGORY_RATIO,
+}: CategoryRatioProps) {
+  const ratios = data?.global_topic_ratios ?? [];
+
+  return (
+    <SectionCard title="카테고리 비율">
+      <S.ChartPlaceholder>
+        {ratios.length > 0 && (
+          <S.ChartBarContainer>
+            {ratios.map((item, i) => (
+              <S.ChartBar
+                key={item.category}
+                $width={item.percentage}
+                $color={
+                  DEFAULT_CATEGORY_COLORS[item.category] ??
+                  CATEGORY_COLORS[i % CATEGORY_COLORS.length]
+                }
+              />
+            ))}
+          </S.ChartBarContainer>
+        )}
+      </S.ChartPlaceholder>
+      <S.CategoryList>
+        {ratios.map((item, i) => (
+          <S.CategoryItem key={item.category}>
+            <S.CategoryDot
+              $color={
+                DEFAULT_CATEGORY_COLORS[item.category] ??
+                CATEGORY_COLORS[i % CATEGORY_COLORS.length]
+              }
+            />
+            {item.category} ({item.count}개)
+          </S.CategoryItem>
+        ))}
+      </S.CategoryList>
+    </SectionCard>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/CategoryRatio/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/CategoryRatio/index.ts
@@ -1,0 +1,1 @@
+export * from "./CategoryRatio";

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/GardenGraph.mocks.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/GardenGraph.mocks.ts
@@ -1,0 +1,13 @@
+export interface DayRecordPost {
+  id: string;
+  title: string;
+  url?: string;
+  category: string;
+}
+
+/** mock 포스트 */
+export const MOCK_DAY_RECORD_POSTS: DayRecordPost[] = [
+  { id: "p1", title: "LLM 파인튜닝 가이드", url: "#", category: "AI" },
+  { id: "p2", title: "Spring Boot 3.2 새 기능", url: "#", category: "Backend" },
+  { id: "p3", title: "React 19 use() 훅", url: "#", category: "Frontend" },
+];

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/GardenGraph.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/GardenGraph.styled.ts
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+
+export const Section = styled.section`
+  padding: 1.5rem;
+  border: 1px solid ${({ theme }) => theme.gray[200]};
+  border-radius: 12px;
+  background: white;
+  margin-bottom: 2rem;
+`;
+
+export const Content = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 1.5rem;
+`;

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/GardenGraph.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/GardenGraph.tsx
@@ -1,0 +1,59 @@
+import { GardenCalendar, GardenDetail, GardenGraphHeader } from "./components";
+import {
+  DEFAULT_GARDEN_FRIENDS,
+  DEFAULT_PLANT_FRIENDS,
+  type GardenGraphProps,
+} from "./GardenGraph.types";
+import * as S from "./GardenGraph.styled";
+
+export function GardenGraph({
+  year = new Date().getFullYear(),
+  month = new Date().getMonth() + 1,
+  onYearChange,
+  onMonthChange,
+  gardenFriends = DEFAULT_GARDEN_FRIENDS,
+  plantFriends = DEFAULT_PLANT_FRIENDS,
+  selectedDay,
+  isDetailView,
+  bounds,
+  days,
+  monthName,
+  postsByCategory,
+  handleDayClick,
+  handleCloseDetail,
+}: GardenGraphProps) {
+  return (
+    <S.Section>
+      <GardenGraphHeader
+        year={year}
+        month={month}
+        monthName={monthName}
+        isDetailView={isDetailView}
+        selectedDay={selectedDay}
+        bounds={bounds}
+        onCloseDetail={handleCloseDetail}
+        onYearChange={onYearChange}
+        onMonthChange={onMonthChange}
+      />
+      <S.Content>
+        {isDetailView ? (
+          <GardenDetail
+            year={year}
+            month={month}
+            day={selectedDay!}
+            postsByCategory={postsByCategory}
+          />
+        ) : (
+          <GardenCalendar
+            days={days}
+            monthName={monthName}
+            selectedDay={selectedDay}
+            gardenFriends={gardenFriends}
+            plantFriends={plantFriends}
+            onDayClick={handleDayClick}
+          />
+        )}
+      </S.Content>
+    </S.Section>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/GardenGraph.types.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/GardenGraph.types.ts
@@ -1,0 +1,43 @@
+import type { DayCellData } from "./gardenGraph.utils";
+import type { DayRecordPost } from "./GardenGraph.mocks";
+
+export interface GardenFriend {
+  name: string;
+  category: string;
+}
+
+export interface GardenGraphBounds {
+  minYear: number;
+  minMonth: number;
+  maxYear: number;
+  maxMonth: number;
+}
+
+export interface GardenGraphProps {
+  year?: number;
+  month?: number;
+  onYearChange?: (year: number) => void;
+  onMonthChange?: (month: number) => void;
+  gardenFriends?: GardenFriend[];
+  plantFriends?: GardenFriend[];
+  selectedDay: number | null;
+  isDetailView: boolean;
+  bounds: GardenGraphBounds;
+  days: DayCellData[];
+  monthName: string;
+  postsByCategory: Record<string, DayRecordPost[]>;
+  handleDayClick: (day: number | null) => void;
+  handleCloseDetail: () => void;
+}
+
+export const DEFAULT_GARDEN_FRIENDS: GardenFriend[] = [
+  { name: "두더지", category: "category" },
+  { name: "돌맹이", category: "category" },
+  { name: "달팽이", category: "category" },
+];
+
+export const DEFAULT_PLANT_FRIENDS: GardenFriend[] = [
+  { name: "당근", category: "category" },
+  { name: "꽃", category: "category" },
+  { name: "버섯", category: "category" },
+];

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/DayRecordPosts/DayRecordPosts.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/DayRecordPosts/DayRecordPosts.styled.ts
@@ -1,0 +1,72 @@
+import styled from "@emotion/styled";
+
+export const Section = styled.section`
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+`;
+
+export const CategoryBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const CategoryHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+`;
+
+export const CategoryCount = styled.span`
+  color: ${({ theme }) => theme.gray[500]};
+  font-weight: 400;
+`;
+
+export const CategoryBadge = styled.span<{ $color: string }>`
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  background: ${({ $color }) => $color};
+  flex-shrink: 0;
+`;
+
+export const PostList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const PostItem = styled.li`
+  width: 100%;
+  min-height: 40px;
+  background: ${({ theme }) => theme.gray[100]};
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  padding: 0 0.75rem;
+  font-size: 0.875rem;
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const EmptyMessage = styled.p`
+  margin: 0;
+  font-size: 0.8125rem;
+  color: ${({ theme }) => theme.gray[500]};
+`;

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/DayRecordPosts/DayRecordPosts.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/DayRecordPosts/DayRecordPosts.tsx
@@ -1,0 +1,57 @@
+import * as S from "./DayRecordPosts.styled";
+
+export interface Post {
+  id: string;
+  title: string;
+  url?: string;
+  category: string;
+}
+
+interface DayRecordPostsProps {
+  postsByCategory: Record<string, Post[]>;
+  categoryColors: Record<string, string>;
+}
+
+export function DayRecordPosts({
+  postsByCategory,
+  categoryColors,
+}: DayRecordPostsProps) {
+  const categories = Object.keys(postsByCategory).sort();
+  const totalPosts = categories.reduce(
+    (sum, cat) => sum + postsByCategory[cat].length,
+    0
+  );
+
+  if (totalPosts === 0) {
+    return (
+      <S.Section>
+        <S.EmptyMessage>이 날 작성한 글이 없습니다.</S.EmptyMessage>
+      </S.Section>
+    );
+  }
+
+  return (
+    <S.Section>
+      {categories.map((category) => {
+        const posts = postsByCategory[category];
+        const color = categoryColors[category] ?? "#94a3b8";
+        return (
+          <S.CategoryBlock key={category}>
+            <S.CategoryHeader>
+              <S.CategoryBadge $color={color} />
+              <span>{category}</span>
+              <S.CategoryCount>({posts.length}편)</S.CategoryCount>
+            </S.CategoryHeader>
+            <S.PostList>
+              {posts.map((post) => (
+                <S.PostItem key={post.id}>
+                  {post.url ? <a href={post.url}>{post.title}</a> : post.title}
+                </S.PostItem>
+              ))}
+            </S.PostList>
+          </S.CategoryBlock>
+        );
+      })}
+    </S.Section>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/DayRecordPosts/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/DayRecordPosts/index.ts
@@ -1,0 +1,1 @@
+export * from "./DayRecordPosts";

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenCalendar/GardenCalendar.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenCalendar/GardenCalendar.styled.ts
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+
+export const GridWrapper = styled.div`
+  flex: 1;
+  min-width: 0;
+  padding: 1rem;
+  background: ${({ theme }) => theme.gray[100]};
+  border-radius: 8px;
+`;
+
+export const Grid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 12px;
+`;
+
+export const Sidebar = styled.aside`
+  width: 200px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+`;

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenCalendar/GardenCalendar.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenCalendar/GardenCalendar.tsx
@@ -1,0 +1,54 @@
+import type { DayCellData } from "../../gardenGraph.utils";
+import { DayCell } from "@jandi-fe/ui";
+import type { GardenFriend } from "../../GardenGraph.types";
+import { LegendSection } from "../LegendSection";
+import * as S from "./GardenCalendar.styled";
+
+interface GardenCalendarProps {
+  days: DayCellData[];
+  monthName: string;
+  selectedDay: number | null;
+  gardenFriends: GardenFriend[];
+  plantFriends: GardenFriend[];
+  onDayClick: (day: number | null) => void;
+}
+
+export function GardenCalendar({
+  days,
+  monthName,
+  selectedDay,
+  gardenFriends,
+  plantFriends,
+  onDayClick,
+}: GardenCalendarProps) {
+  return (
+    <>
+      <S.GridWrapper>
+        <S.Grid>
+          {days.map((cell, i) => (
+            <DayCell
+              key={i}
+              day={cell.day}
+              category={cell.category}
+              postCount={cell.postCount}
+              color={cell.color}
+              isDisabled={cell.isDisabled}
+              selected={selectedDay === cell.day}
+              onClick={() => onDayClick(cell.day)}
+            />
+          ))}
+        </S.Grid>
+      </S.GridWrapper>
+      <S.Sidebar>
+        <LegendSection
+          title={`${monthName}의 정원 친구들`}
+          friends={gardenFriends}
+        />
+        <LegendSection
+          title={`${monthName}의 식물 친구들`}
+          friends={plantFriends}
+        />
+      </S.Sidebar>
+    </>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenCalendar/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenCalendar/index.ts
@@ -1,0 +1,1 @@
+export { GardenCalendar } from "./GardenCalendar";

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenDetail/GardenDetail.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenDetail/GardenDetail.styled.ts
@@ -1,0 +1,59 @@
+import styled from "@emotion/styled";
+
+export const Section = styled.section`
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+  min-height: 320px;
+`;
+
+export const GardenArea = styled.div`
+  flex: 1;
+  min-width: 0;
+  padding: 1.5rem;
+  background: ${({ theme }) => theme.gray[100]};
+  border-radius: 12px;
+  border: 1px solid ${({ theme }) => theme.gray[200]};
+  position: relative;
+`;
+
+export const FunButton = styled.button`
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid ${({ theme }) => theme.gray[400]};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.gray[500]};
+  color: white;
+  font-size: 0.75rem;
+  cursor: pointer;
+
+  &:hover {
+    background: ${({ theme }) => theme.gray[600]};
+  }
+`;
+
+export const RecordArea = styled.aside`
+  width: 200px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+`;
+
+export const RecordTitle = styled.h3`
+  margin: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+`;
+
+export const RecordContent = styled.div`
+  flex: 1;
+  min-height: 200px;
+  background: ${({ theme }) => theme.gray[100]};
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.gray[200]};
+  padding: 1rem;
+  overflow-y: auto;
+`;

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenDetail/GardenDetail.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenDetail/GardenDetail.tsx
@@ -1,0 +1,37 @@
+import { DEFAULT_CATEGORY_COLORS } from "../../../../MyGardenPage.constants";
+import type { DayRecordPost } from "../../GardenGraph.mocks";
+import { DayRecordPosts } from "../DayRecordPosts";
+import * as S from "./GardenDetail.styled";
+
+interface GardenDetailProps {
+  year: number;
+  month: number;
+  day: number;
+  postsByCategory: Record<string, DayRecordPost[]>;
+}
+
+export function GardenDetail({
+  year,
+  month,
+  day,
+  postsByCategory,
+}: GardenDetailProps) {
+  const dateStr = `${year}년 ${month}월 ${day}일`;
+
+  return (
+    <S.Section>
+      <S.GardenArea>
+        <S.FunButton type="button">캐릭터를 놀아주는 버튼</S.FunButton>
+      </S.GardenArea>
+      <S.RecordArea>
+        <S.RecordTitle>{dateStr}의 기록</S.RecordTitle>
+        <S.RecordContent>
+          <DayRecordPosts
+            postsByCategory={postsByCategory}
+            categoryColors={DEFAULT_CATEGORY_COLORS}
+          />
+        </S.RecordContent>
+      </S.RecordArea>
+    </S.Section>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenDetail/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenDetail/index.ts
@@ -1,0 +1,1 @@
+export * from "./GardenDetail";

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenGraphHeader/GardenGraphHeader.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenGraphHeader/GardenGraphHeader.styled.ts
@@ -1,0 +1,46 @@
+import styled from "@emotion/styled";
+
+export const Header = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+`;
+
+export const HeaderLeft = styled.div`
+  flex: 1;
+`;
+
+export const Title = styled.h2`
+  margin: 0 0 0.25rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+`;
+
+export const Subtitle = styled.p`
+  margin: 0;
+  font-size: 0.875rem;
+  color: ${({ theme }) => theme.gray[500]};
+`;
+
+export const HeaderRight = styled.div`
+  flex-shrink: 0;
+`;
+
+export const BackButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid ${({ theme }) => theme.gray[300]};
+  border-radius: 8px;
+  background: white;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: inherit;
+
+  &:hover {
+    background: ${({ theme }) => theme.gray[100]};
+  }
+`;

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenGraphHeader/GardenGraphHeader.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenGraphHeader/GardenGraphHeader.tsx
@@ -1,0 +1,67 @@
+import { PeriodSelector } from "../PeriodSelector";
+import * as S from "./GardenGraphHeader.styled";
+
+interface GardenGraphHeaderProps {
+  year: number;
+  month: number;
+  monthName: string;
+  isDetailView: boolean;
+  selectedDay: number | null;
+  bounds: {
+    minYear: number;
+    minMonth: number;
+    maxYear: number;
+    maxMonth: number;
+  };
+  onCloseDetail: () => void;
+  onYearChange?: (year: number) => void;
+  onMonthChange?: (month: number) => void;
+}
+
+export function GardenGraphHeader({
+  year,
+  month,
+  monthName,
+  isDetailView,
+  selectedDay,
+  bounds,
+  onCloseDetail,
+  onYearChange,
+  onMonthChange,
+}: GardenGraphHeaderProps) {
+  return (
+    <S.Header>
+      <S.HeaderLeft>
+        <S.Title>
+          {year}년 {monthName}
+          {isDetailView ? ` ${selectedDay}일의` : ""} 잔디밭
+        </S.Title>
+        <S.Subtitle>
+          {isDetailView ? "comment" : "정원이 무성하게 자라고 있습니다"}
+        </S.Subtitle>
+      </S.HeaderLeft>
+      <S.HeaderRight>
+        {isDetailView ? (
+          <S.BackButton
+            type="button"
+            onClick={onCloseDetail}
+            aria-label="달력 보기"
+          >
+            ← 달력 보기
+          </S.BackButton>
+        ) : (
+          <PeriodSelector
+            year={year}
+            month={month}
+            minYear={bounds.minYear}
+            minMonth={bounds.minMonth}
+            maxYear={bounds.maxYear}
+            maxMonth={bounds.maxMonth}
+            onYearChange={onYearChange}
+            onMonthChange={onMonthChange}
+          />
+        )}
+      </S.HeaderRight>
+    </S.Header>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenGraphHeader/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/GardenGraphHeader/index.ts
@@ -1,0 +1,1 @@
+export { GardenGraphHeader } from "./GardenGraphHeader";

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/LegendSection/LegendSection.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/LegendSection/LegendSection.styled.ts
@@ -1,0 +1,48 @@
+import styled from "@emotion/styled";
+
+export const Section = styled.div``;
+
+export const SectionTitle = styled.h3`
+  margin: 0 0 0.5rem 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+`;
+
+export const List = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const Item = styled.li`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+export const Icon = styled.span`
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: ${({ theme }) => theme.gray[200]};
+  flex-shrink: 0;
+`;
+
+export const ItemContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+`;
+
+export const ItemName = styled.span`
+  font-size: 0.8125rem;
+  font-weight: 500;
+`;
+
+export const ItemSub = styled.span`
+  font-size: 0.6875rem;
+  color: ${({ theme }) => theme.gray[500]};
+`;

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/LegendSection/LegendSection.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/LegendSection/LegendSection.tsx
@@ -1,0 +1,26 @@
+import type { GardenFriend } from "../../GardenGraph.types";
+import * as S from "./LegendSection.styled";
+
+interface LegendSectionProps {
+  title: string;
+  friends: GardenFriend[];
+}
+
+export function LegendSection({ title, friends }: LegendSectionProps) {
+  return (
+    <S.Section>
+      <S.SectionTitle>{title}</S.SectionTitle>
+      <S.List>
+        {friends.map((friend) => (
+          <S.Item key={friend.name}>
+            <S.Icon />
+            <S.ItemContent>
+              <S.ItemName>{friend.name}</S.ItemName>
+              <S.ItemSub>{friend.category}</S.ItemSub>
+            </S.ItemContent>
+          </S.Item>
+        ))}
+      </S.List>
+    </S.Section>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/LegendSection/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/LegendSection/index.ts
@@ -1,0 +1,1 @@
+export { LegendSection } from "./LegendSection";

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/PeriodSelector/PeriodSelector.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/PeriodSelector/PeriodSelector.styled.ts
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+export const ArrowButton = styled.button`
+  padding: 0.5rem;
+  border: 1px solid ${({ theme }) => theme.gray[300]};
+  border-radius: 8px;
+  background: white;
+  font-size: 1rem;
+  cursor: pointer;
+  color: inherit;
+  line-height: 1;
+
+  &:hover:not(:disabled) {
+    background: ${({ theme }) => theme.gray[100]};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+export const PeriodText = styled.span`
+  min-width: 7rem;
+  text-align: center;
+  font-size: 0.875rem;
+  font-weight: 500;
+`;

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/PeriodSelector/PeriodSelector.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/PeriodSelector/PeriodSelector.tsx
@@ -1,0 +1,91 @@
+import * as S from "./PeriodSelector.styled";
+
+interface PeriodSelectorProps {
+  year: number;
+  month: number;
+  minYear: number;
+  minMonth: number;
+  maxYear: number;
+  maxMonth: number;
+  onYearChange?: (year: number) => void;
+  onMonthChange?: (month: number) => void;
+}
+
+/** (y, m)이 (refY, refM) 이전 또는 같은 지 비교 */
+function isBeforeOrEqual(
+  y: number,
+  m: number,
+  refY: number,
+  refM: number
+): boolean {
+  return y < refY || (y === refY && m <= refM);
+}
+
+/** (y, m)이 (refY, refM) 이후 또는 같은 지 비교 */
+function isAfterOrEqual(
+  y: number,
+  m: number,
+  refY: number,
+  refM: number
+): boolean {
+  return y > refY || (y === refY && m >= refM);
+}
+
+export function PeriodSelector({
+  year,
+  month,
+  minYear,
+  minMonth,
+  maxYear,
+  maxMonth,
+  onYearChange,
+  onMonthChange,
+}: PeriodSelectorProps) {
+  const isAtMin = isBeforeOrEqual(year, month, minYear, minMonth);
+  const isAtMax = isAfterOrEqual(year, month, maxYear, maxMonth);
+
+  // 1월 이전: 전년 12월로, 12월 다음: 다음해 1월로
+  const handlePrev = () => {
+    if (isAtMin) return;
+    if (month === 1) {
+      onYearChange?.(year - 1);
+      onMonthChange?.(12);
+    } else {
+      onMonthChange?.(month - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (isAtMax) return;
+    if (month === 12) {
+      onYearChange?.(year + 1);
+      onMonthChange?.(1);
+    } else {
+      onMonthChange?.(month + 1);
+    }
+  };
+
+  return (
+    <S.Wrapper>
+      <S.ArrowButton
+        type="button"
+        onClick={handlePrev}
+        aria-label="이전 달"
+        disabled={isAtMin}
+      >
+        &lt;
+      </S.ArrowButton>
+      <S.PeriodText>
+        {year}년 {month}월
+      </S.PeriodText>
+      <S.ArrowButton
+        type="button"
+        onClick={handleNext}
+        aria-label="다음 달"
+        disabled={isAtMax}
+      >
+        &gt;
+      </S.ArrowButton>
+    </S.Wrapper>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/PeriodSelector/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/PeriodSelector/index.ts
@@ -1,0 +1,1 @@
+export * from "./PeriodSelector";

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/components/index.ts
@@ -1,0 +1,6 @@
+export { DayRecordPosts } from "./DayRecordPosts";
+export { GardenCalendar } from "./GardenCalendar";
+export { GardenDetail } from "./GardenDetail";
+export { GardenGraphHeader } from "./GardenGraphHeader";
+export { LegendSection } from "./LegendSection";
+export { PeriodSelector } from "./PeriodSelector";

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/gardenGraph.utils.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/gardenGraph.utils.ts
@@ -1,0 +1,155 @@
+import type { JandiItem, JandiPeriod } from "../../MyGardenPage.mocks";
+
+export interface DayCellData {
+  day: number | null;
+  category: string | null;
+  postCount: number;
+  color: string | null;
+  isFuture?: boolean;
+  /** 조회 불가 여부 */
+  isDisabled?: boolean;
+}
+
+/**
+ * PeriodSelector에서 사용할 수 있는 년/월 범위를 계산합니다.
+ * - max: 항상 오늘
+ * - min: jandiData 최초 날짜 > period.start > 오늘(데이터 없을 때)
+ */
+export function getMinMaxBounds(
+  jandiData: JandiItem[],
+  period: JandiPeriod | undefined
+): { minYear: number; minMonth: number; maxYear: number; maxMonth: number } {
+  const now = new Date();
+  const maxYear = now.getFullYear();
+  const maxMonth = now.getMonth() + 1;
+
+  let minYear: number;
+  let minMonth: number;
+  if (jandiData.length > 0) {
+    const sorted = [...jandiData].sort((a, b) => a.date.localeCompare(b.date));
+    const [y, m] = sorted[0].date.split("-").map(Number);
+    minYear = y;
+    minMonth = m;
+  } else if (period) {
+    const [y, m] = period.start.split("-").map(Number);
+    minYear = y;
+    minMonth = m;
+  } else {
+    minYear = maxYear;
+    minMonth = maxMonth;
+  }
+
+  if (minYear > maxYear || (minYear === maxYear && minMonth > maxMonth)) {
+    minYear = maxYear;
+    minMonth = maxMonth;
+  }
+  return { minYear, minMonth, maxYear, maxMonth };
+}
+
+/** 조회 가능한 가장 이른 날짜 (jandiData 최초 또는 period.start) */
+export function getFirstDate(
+  jandiData: JandiItem[],
+  period: JandiPeriod | undefined
+): string | null {
+  if (jandiData.length > 0) {
+    const sorted = [...jandiData].sort((a, b) => a.date.localeCompare(b.date));
+    return sorted[0].date;
+  }
+  return period?.start ?? null;
+}
+
+/** (year, month, day)가 firstDate보다 이전인지 비교 */
+export function isBeforeFirstDate(
+  year: number,
+  month: number,
+  day: number,
+  firstDate: string | null
+): boolean {
+  if (!firstDate) return false;
+  const [fy, fm, fd] = firstDate.split("-").map(Number);
+  if (year < fy) return true;
+  if (year > fy) return false;
+  if (month < fm) return true;
+  if (month > fm) return false;
+  return day < fd;
+}
+
+/** (year, month, day)가 오늘보다 나중인지 비교 */
+export function isFutureDate(
+  year: number,
+  month: number,
+  day: number
+): boolean {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = now.getMonth() + 1;
+  const d = now.getDate();
+  if (year > y) return true;
+  if (year < y) return false;
+  if (month > m) return true;
+  if (month < m) return false;
+  return day > d;
+}
+
+/**
+ * 달력 그리드용 셀 배열을 생성합니다.
+ * - 앞쪽: firstDay만큼 패딩(day: null)으로 요일 정렬
+ * - isDisabled: 클릭 불가, 배경색으로 비활성 표시
+ */
+export function buildDayCells(
+  year: number,
+  month: number,
+  jandiData: JandiItem[],
+  categoryColors: Record<string, string>,
+  firstDate: string | null
+): DayCellData[] {
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const firstDay = new Date(year, month - 1, 1).getDay();
+  const cells: DayCellData[] = [];
+  const dataByDate = new Map(
+    jandiData.filter((j) => j.post_count > 0).map((j) => [j.date, j])
+  );
+
+  // 1일이 시작되는 요일까지 빈 셀(패딩) 추가
+  for (let i = 0; i < firstDay; i++) {
+    cells.push({
+      day: null,
+      category: null,
+      postCount: 0,
+      color: null,
+    });
+  }
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dateStr = `${year}-${String(month).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+    const item = dataByDate.get(dateStr);
+    const category = item?.category ?? null;
+    const postCount = item?.post_count ?? 0;
+    const color = category ? (categoryColors[category] ?? null) : null;
+    const isFuture = isFutureDate(year, month, d);
+    const isBeforeFirst = isBeforeFirstDate(year, month, d, firstDate);
+    const isDisabled = isFuture || isBeforeFirst;
+    cells.push({
+      day: d,
+      category: isDisabled ? null : category,
+      postCount: isDisabled ? 0 : postCount,
+      color: isDisabled ? null : color,
+      isFuture,
+      isDisabled,
+    });
+  }
+
+  return cells;
+}
+
+/** 포스트 배열을 category 키로 그룹화 (DayRecordPosts 등에서 사용) */
+export function groupPostsByCategory<T extends { category: string }>(
+  posts: T[]
+): Record<string, T[]> {
+  const map: Record<string, T[]> = {};
+  for (const p of posts) {
+    if (!map[p.category]) map[p.category] = [];
+    map[p.category].push(p);
+  }
+  return map;
+}

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/index.ts
@@ -1,0 +1,1 @@
+export * from "./GardenGraph";

--- a/apps/web/src/pages/MyGardenPage/components/GardenGraph/useGardenGraph.ts
+++ b/apps/web/src/pages/MyGardenPage/components/GardenGraph/useGardenGraph.ts
@@ -1,0 +1,66 @@
+import { useMemo, useState } from "react";
+import type { JandiItem, JandiPeriod } from "../../MyGardenPage.mocks";
+import { DEFAULT_CATEGORY_COLORS } from "../../MyGardenPage.constants";
+import {
+  buildDayCells,
+  getFirstDate,
+  getMinMaxBounds,
+  groupPostsByCategory,
+} from "./gardenGraph.utils";
+import { MOCK_DAY_RECORD_POSTS } from "./GardenGraph.mocks";
+
+interface UseGardenGraphParams {
+  year: number;
+  month: number;
+  jandiData: JandiItem[];
+  period?: JandiPeriod;
+}
+
+export function useGardenGraph({
+  year,
+  month,
+  jandiData,
+  period,
+}: UseGardenGraphParams) {
+  const [selectedDay, setSelectedDay] = useState<number | null>(null);
+
+  const bounds = useMemo(
+    () => getMinMaxBounds(jandiData, period),
+    [jandiData, period]
+  );
+  const firstDate = useMemo(
+    () => getFirstDate(jandiData, period),
+    [jandiData, period]
+  );
+  const days = useMemo(
+    () =>
+      buildDayCells(year, month, jandiData, DEFAULT_CATEGORY_COLORS, firstDate),
+    [year, month, jandiData, firstDate]
+  );
+  const postsByCategory = useMemo(
+    () => groupPostsByCategory(MOCK_DAY_RECORD_POSTS),
+    []
+  );
+
+  // 같은 날짜 클릭 시 토글(다시 클릭하면 선택 해제)
+  const handleDayClick = (day: number | null) => {
+    if (day === null) return;
+    setSelectedDay((prev) => (prev === day ? null : day));
+  };
+
+  const handleCloseDetail = () => setSelectedDay(null);
+
+  const isDetailView = selectedDay !== null;
+  const monthName = `${month}월`;
+
+  return {
+    selectedDay,
+    isDetailView,
+    bounds,
+    days,
+    monthName,
+    postsByCategory,
+    handleDayClick,
+    handleCloseDetail,
+  };
+}

--- a/apps/web/src/pages/MyGardenPage/components/RecentPosts/RecentPosts.mocks.ts
+++ b/apps/web/src/pages/MyGardenPage/components/RecentPosts/RecentPosts.mocks.ts
@@ -1,0 +1,35 @@
+export interface RecentPost {
+  id: string;
+  title: string;
+  url?: string;
+  excerpt?: string;
+  date?: string;
+  category?: string;
+}
+
+export const MOCK_RECENT_POSTS: RecentPost[] = [
+  {
+    id: "1",
+    title: "LLM 파인튜닝 가이드",
+    url: "#",
+    excerpt: "대규모 언어 모델을 나만의 데이터로 튜닝하는 방법을 소개합니다.",
+    date: "2026.01.15",
+    category: "AI",
+  },
+  {
+    id: "2",
+    title: "Spring Boot 3.2 새 기능",
+    url: "#",
+    excerpt: "Spring Boot 3.2에서 추가된 주요 기능들을 살펴봅니다.",
+    date: "2026.01.12",
+    category: "Backend",
+  },
+  {
+    id: "3",
+    title: "React 19 use() 훅",
+    url: "#",
+    excerpt: "React 19의 새로운 use 훅으로 비동기 컴포넌트를 다루는 방법.",
+    date: "2026.01.08",
+    category: "Frontend",
+  },
+];

--- a/apps/web/src/pages/MyGardenPage/components/RecentPosts/RecentPosts.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/RecentPosts/RecentPosts.styled.ts
@@ -1,0 +1,81 @@
+import styled from "@emotion/styled";
+
+export const PostList = styled.ul`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+`;
+
+export const PostCard = styled.li`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  border: 1px solid ${({ theme }) => theme.gray[200]};
+  border-radius: 8px;
+  overflow: hidden;
+  background: white;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.gray[300]};
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+    display: flex;
+    width: 100%;
+  }
+`;
+
+export const CategoryDot = styled.span<{ $color: string }>`
+  width: 8px;
+  height: 8px;
+  min-width: 8px;
+  border-radius: 50%;
+  background: ${({ $color }) => $color};
+  flex-shrink: 0;
+`;
+
+export const CategoryName = styled.span`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.gray[500]};
+  flex-shrink: 0;
+`;
+
+export const CardContent = styled.div`
+  flex: 1;
+  min-width: 0;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+export const CardTitle = styled.span`
+  flex: 1;
+  min-width: 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.4;
+`;
+
+export const CardDate = styled.span`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.gray[500]};
+  flex-shrink: 0;
+`;
+
+export const PostCardPlaceholder = styled.li`
+  width: 100%;
+  height: 48px;
+  background: ${({ theme }) => theme.gray[100]};
+  border-radius: 8px;
+  border: 1px dashed ${({ theme }) => theme.gray[300]};
+`;

--- a/apps/web/src/pages/MyGardenPage/components/RecentPosts/RecentPosts.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/RecentPosts/RecentPosts.tsx
@@ -1,0 +1,46 @@
+import { DEFAULT_CATEGORY_COLORS } from "../../MyGardenPage.constants";
+import { SectionCard } from "../SectionCard";
+import { type RecentPost, MOCK_RECENT_POSTS } from "./RecentPosts.mocks";
+import * as S from "./RecentPosts.styled";
+
+interface RecentPostsProps {
+  posts?: RecentPost[];
+}
+
+const PLACEHOLDER_COUNT = 3;
+
+export function RecentPosts({ posts = MOCK_RECENT_POSTS }: RecentPostsProps) {
+  const displayCount = posts.length > 0 ? posts.length : PLACEHOLDER_COUNT;
+
+  return (
+    <SectionCard title="최근 포스트">
+      <S.PostList>
+        {posts.length > 0
+          ? posts.map((post) => {
+              const color =
+                post.category && DEFAULT_CATEGORY_COLORS[post.category]
+                  ? DEFAULT_CATEGORY_COLORS[post.category]
+                  : "#94a3b8";
+              const content = (
+                <S.CardContent>
+                  <S.CategoryDot $color={color} />
+                  {post.category && (
+                    <S.CategoryName>{post.category}</S.CategoryName>
+                  )}
+                  <S.CardTitle>{post.title}</S.CardTitle>
+                  {post.date && <S.CardDate>{post.date}</S.CardDate>}
+                </S.CardContent>
+              );
+              return (
+                <S.PostCard key={post.id}>
+                  {post.url ? <a href={post.url}>{content}</a> : content}
+                </S.PostCard>
+              );
+            })
+          : Array.from({ length: displayCount }).map((_, i) => (
+              <S.PostCardPlaceholder key={i} />
+            ))}
+      </S.PostList>
+    </SectionCard>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/RecentPosts/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/RecentPosts/index.ts
@@ -1,0 +1,1 @@
+export * from "./RecentPosts";

--- a/apps/web/src/pages/MyGardenPage/components/SectionCard/SectionCard.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/SectionCard/SectionCard.styled.ts
@@ -1,0 +1,16 @@
+import styled from "@emotion/styled";
+
+export const Section = styled.section`
+  flex: 1;
+  min-width: 0;
+  padding: 1.5rem;
+  border: 1px solid ${({ theme }) => theme.gray[200]};
+  border-radius: 12px;
+  background: white;
+`;
+
+export const Title = styled.h2`
+  margin: 0 0 1rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+`;

--- a/apps/web/src/pages/MyGardenPage/components/SectionCard/SectionCard.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/SectionCard/SectionCard.tsx
@@ -1,0 +1,15 @@
+import * as S from "./SectionCard.styled";
+
+interface SectionCardProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export function SectionCard({ title, children }: SectionCardProps) {
+  return (
+    <S.Section>
+      <S.Title>{title}</S.Title>
+      {children}
+    </S.Section>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/SectionCard/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/SectionCard/index.ts
@@ -1,0 +1,1 @@
+export * from "./SectionCard";

--- a/apps/web/src/pages/MyGardenPage/components/StatCard/StatCard.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/StatCard/StatCard.styled.ts
@@ -1,0 +1,43 @@
+import styled from "@emotion/styled";
+
+export const Card = styled.article`
+  flex: 1;
+  min-width: 0;
+  padding: 1.25rem;
+  border: 1px solid ${({ theme }) => theme.gray[200]};
+  border-radius: 12px;
+  background: white;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+`;
+
+export const Label = styled.span`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.gray[500]};
+`;
+
+export const Value = styled.span`
+  font-size: 1.5rem;
+  font-weight: 700;
+`;
+
+export const Description = styled.span`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.gray[500]};
+`;
+
+export const IconPlaceholder = styled.span`
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.gray[200]};
+`;

--- a/apps/web/src/pages/MyGardenPage/components/StatCard/StatCard.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/StatCard/StatCard.tsx
@@ -1,0 +1,20 @@
+import * as S from "./StatCard.styled";
+
+interface StatCardProps {
+  label: string;
+  value: string | number;
+  description: string;
+}
+
+export function StatCard({ label, value, description }: StatCardProps) {
+  return (
+    <S.Card>
+      <S.Content>
+        <S.Label>{label}</S.Label>
+        <S.Value>{value}</S.Value>
+        <S.Description>{description}</S.Description>
+      </S.Content>
+      <S.IconPlaceholder />
+    </S.Card>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/StatCard/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/StatCard/index.ts
@@ -1,0 +1,1 @@
+export * from "./StatCard";

--- a/apps/web/src/pages/MyGardenPage/components/SummaryCards/SummaryCards.styled.ts
+++ b/apps/web/src/pages/MyGardenPage/components/SummaryCards/SummaryCards.styled.ts
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.section`
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+`;

--- a/apps/web/src/pages/MyGardenPage/components/SummaryCards/SummaryCards.tsx
+++ b/apps/web/src/pages/MyGardenPage/components/SummaryCards/SummaryCards.tsx
@@ -1,0 +1,35 @@
+import type { UserSummary } from "../../MyGardenPage.mocks";
+import { StatCard } from "../StatCard";
+import * as S from "./SummaryCards.styled";
+
+interface SummaryCardsProps {
+  userSummary: UserSummary;
+}
+
+export function SummaryCards({ userSummary }: SummaryCardsProps) {
+  const totalPosts = userSummary.total_posts;
+  const activeDays = userSummary.total_active_days;
+  const currentStreak = userSummary.current_streak;
+  const longestStreak = userSummary.max_streak;
+
+  return (
+    <S.Wrapper>
+      <StatCard label="총 글 수" value={totalPosts} description="전체 포스팅" />
+      <StatCard
+        label="활동일수"
+        value={activeDays}
+        description="글 작성한 날"
+      />
+      <StatCard
+        label="현재 기록"
+        value={`${currentStreak}일`}
+        description="연속 작성 중"
+      />
+      <StatCard
+        label="최장 기록"
+        value={`${longestStreak}일`}
+        description="최고 기록"
+      />
+    </S.Wrapper>
+  );
+}

--- a/apps/web/src/pages/MyGardenPage/components/SummaryCards/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/SummaryCards/index.ts
@@ -1,0 +1,1 @@
+export * from "./SummaryCards";

--- a/apps/web/src/pages/MyGardenPage/components/index.ts
+++ b/apps/web/src/pages/MyGardenPage/components/index.ts
@@ -1,0 +1,6 @@
+export * from "./CategoryRatio";
+export * from "./GardenGraph";
+export * from "./RecentPosts";
+export * from "./SectionCard";
+export * from "./StatCard";
+export * from "./SummaryCards";

--- a/apps/web/src/pages/MyGardenPage/index.ts
+++ b/apps/web/src/pages/MyGardenPage/index.ts
@@ -1,1 +1,1 @@
-export { MyGardenPage } from "./MyGardenPage";
+export * from "./MyGardenPage";

--- a/apps/web/src/pages/SettingsPage/index.ts
+++ b/apps/web/src/pages/SettingsPage/index.ts
@@ -1,1 +1,1 @@
-export { SettingsPage } from "./SettingsPage";
+export * from "./SettingsPage";

--- a/apps/web/src/pages/SignupPage/index.ts
+++ b/apps/web/src/pages/SignupPage/index.ts
@@ -1,1 +1,1 @@
-export { SignupPage } from "./SignupPage";
+export * from "./SignupPage";

--- a/apps/web/src/pages/WidgetPage/index.ts
+++ b/apps/web/src/pages/WidgetPage/index.ts
@@ -1,1 +1,1 @@
-export { WidgetPage } from "./WidgetPage";
+export * from "./WidgetPage";

--- a/apps/web/src/pages/index.ts
+++ b/apps/web/src/pages/index.ts
@@ -1,6 +1,6 @@
-export { MyGardenPage } from "./MyGardenPage";
-export { WidgetPage } from "./WidgetPage";
-export { SettingsPage } from "./SettingsPage";
-export { AccountPage } from "./AccountPage";
-export { LoginPage } from "./LoginPage";
-export { SignupPage } from "./SignupPage";
+export * from "./MyGardenPage";
+export * from "./WidgetPage";
+export * from "./SettingsPage";
+export * from "./AccountPage";
+export * from "./LoginPage";
+export * from "./SignupPage";

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface AuthState {
+  isLoggedIn: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  isLoggedIn: false,
+  login: () => set({ isLoggedIn: true }),
+  logout: () => set({ isLoggedIn: false }),
+}));

--- a/packages/ui/src/components/DayCell/DayCell.styled.ts
+++ b/packages/ui/src/components/DayCell/DayCell.styled.ts
@@ -37,4 +37,9 @@ export const Cell = styled.button<{
     opacity: 0.6;
     cursor: not-allowed;
   }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.gray[700]};
+    outline-offset: 2px;
+  }
 `;

--- a/packages/ui/src/components/DayCell/DayCell.styled.ts
+++ b/packages/ui/src/components/DayCell/DayCell.styled.ts
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled";
+
+export const Cell = styled.button<{
+  $variant: "empty" | "filled";
+  $color: string | null;
+  $selected?: boolean;
+  $clickable?: boolean;
+  $disabled?: boolean;
+}>`
+  aspect-ratio: 1;
+  border-radius: 6px;
+  border: none;
+  background: ${({ $variant, $color, $disabled, theme }) =>
+    $disabled
+      ? theme.gray[100]
+      : $variant === "filled" && $color
+        ? $color
+        : theme.gray[50]};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  font-size: 0.625rem;
+  font-weight: 500;
+  color: ${({ $variant, $color }) =>
+    $variant === "filled" && $color ? "white" : "inherit"};
+  text-shadow: ${({ $variant, $color }) =>
+    $variant === "filled" && $color ? "0 0 1px rgba(0, 0, 0, 0.5)" : "none"};
+  cursor: ${({ $clickable }) => ($clickable ? "pointer" : "not-allowed")};
+  padding: 0;
+
+  &:hover {
+    opacity: ${({ $clickable }) => ($clickable ? 0.9 : 1)};
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+`;

--- a/packages/ui/src/components/DayCell/DayCell.tsx
+++ b/packages/ui/src/components/DayCell/DayCell.tsx
@@ -23,16 +23,27 @@ export function DayCell({
   const variant = category && postCount > 0 ? "filled" : "empty";
   const clickable = day !== null && !isDisabled;
 
+  const dateText = day !== null ? `${day}일` : "";
+  const ariaLabel =
+    day !== null
+      ? postCount > 0
+        ? `${dateText}, ${postCount}개`
+        : dateText
+      : undefined;
+
   return (
     <S.Cell
       type="button"
+      aria-label={ariaLabel}
+      aria-hidden={day === null}
+      aria-pressed={clickable ? selected : undefined}
       disabled={!clickable}
       $variant={variant}
       $color={variant === "filled" ? color : null}
       $selected={selected}
       $clickable={clickable}
-      $disabled={isDisabled}
-      onClick={clickable ? onClick : undefined}
+      $disabled={!clickable}
+      onClick={onClick}
     />
   );
 }

--- a/packages/ui/src/components/DayCell/DayCell.tsx
+++ b/packages/ui/src/components/DayCell/DayCell.tsx
@@ -1,0 +1,38 @@
+import * as S from "./DayCell.styled";
+
+export interface DayCellProps {
+  day: number | null;
+  category: string | null;
+  postCount?: number;
+  color?: string | null;
+  /** 조회 불가 여부 - 비활성화 */
+  isDisabled?: boolean;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+export function DayCell({
+  day,
+  category,
+  postCount = 0,
+  color = null,
+  isDisabled = false,
+  selected = false,
+  onClick,
+}: DayCellProps) {
+  const variant = category && postCount > 0 ? "filled" : "empty";
+  const clickable = day !== null && !isDisabled;
+
+  return (
+    <S.Cell
+      type="button"
+      disabled={!clickable}
+      $variant={variant}
+      $color={variant === "filled" ? color : null}
+      $selected={selected}
+      $clickable={clickable}
+      $disabled={isDisabled}
+      onClick={clickable ? onClick : undefined}
+    />
+  );
+}

--- a/packages/ui/src/components/DayCell/index.ts
+++ b/packages/ui/src/components/DayCell/index.ts
@@ -1,0 +1,1 @@
+export * from "./DayCell";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./DayCell";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,6 @@
-import "./types/emotion.d.ts";
+/* eslint-disable-next-line @typescript-eslint/triple-slash-reference */
+/// <reference path="./types/emotion.d.ts" />
+
 export * from "./components";
 export { GlobalStyles } from "./GlobalStyles";
 export {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,4 @@
-/// <reference path="./types/emotion.d.ts" />
-
+import "./types/emotion.d.ts";
 export { GlobalStyles } from "./GlobalStyles";
 export {
   colors,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,5 @@
 import "./types/emotion.d.ts";
+export * from "./components";
 export { GlobalStyles } from "./GlobalStyles";
 export {
   colors,


### PR DESCRIPTION
# Pull requests

## 작업 내용

- ErrorBoundary 컴포넌트 추가 및 앱 루트에 적용
- Header 컴포넌트 구현
- widget/web 공통 DayCell 컴포넌트 추가 (`@jandi-fe/ui`)
- MyGardenPage 페이지 UI 구현 (잔디 시각화, 요약 카드, 카테고리 비율, 최근 게시글)
    - mock 데이터 기반 임시 데이터 적용
    - 잔디밭 형식과 일일 정원 구성이 현재 명확하지 않아, 우선 현재 와이어프레임에 맞춰 구현했습니다. 개편이 필요합니다...

## 참고 사항

- MyGardenPage는 현재 mock 데이터로만 동작합니다. 추후 API 연동 시 실제 API 호출로 교체합니다.
- ErrorBoundary는 `ClientError`, `ServerError`, `NetworkError` 타입별로 fallback UI를 다르게 표시합니다.
- DayCell은 `@jandi-fe/ui`에 추가되어 web과 widget에서 공통 사용할 수 있습니다.
    - widget 형태가 아직 확정되지 않아 공통 UI 범위를 정하기 어려웠고, 현재는 위젯이 좁은 영역에 잔디밭 전체를 보여줘야 한다는 전제로 셀만 공통으로 두고, 레이아웃은 web과 widget에서 각각 구현할 수 있도록 했습니다. 
    - 위젯에서는 Day 선택이 안될 수 있음을 고려하여 isDisabled 상태를 추가했습니다. 
    - 필요 시 추후 범위를 확장할 예정입니다.
 

## 주요 코드 설명

`ErrorBoundary.tsx`

- 에러 타입에 따라 아이콘·스타일을 분기하는 `getErrorVariant` 함수 사용
- `ClientError`(4xx), `ServerError`(5xx), `NetworkError`, 일반 `Error` 처리

```typescript
function getErrorVariant(error: Error): ErrorVariant {
  if (error instanceof ClientError) return "ClientError";
  if (error instanceof ServerError) return "ServerError";
  if (error instanceof NetworkError) return "NetworkError";
  return "Error";
}

/// 일부 생략

const variant = getErrorVariant(error);

// fallback UI 렌더링 
return (
  <S.Container>
    <S.Card>
      <S.IconWrapper $variant={variant}>
        {ERROR_ICONS[variant]}
      </S.IconWrapper>
      <S.Message>{error.message}</S.Message>
      <S.ButtonGroup>
        <S.PrimaryButton type="button" onClick={this.handleReset}>다시 시도</S.PrimaryButton>
        <S.SecondaryButton type="button" onClick={this.handleGoHome}>홈으로</S.SecondaryButton>
      </S.ButtonGroup>
      {/* ... */}
    </S.Card>
  </S.Container>
);

```
`DayCell.tsx(@jandi-fe/ui)`

- filled / empty 상태에 따라 스타일이 달라지는 달력 셀 컴포넌트
- isDisabled, selected로 비활성/선택 상태 표현

```typescript
import * as S from "./DayCell.styled";

export interface DayCellProps {
  day: number | null;
  category: string | null;
  postCount?: number;
  color?: string | null;
  /** 조회 불가 여부 - 비활성화 */
  isDisabled?: boolean;
  selected?: boolean;
  onClick?: () => void;
}

export function DayCell({
  day,
  category,
  postCount = 0,
  color = null,
  isDisabled = false,
  selected = false,
  onClick,
}: DayCellProps) {
  const variant = category && postCount > 0 ? "filled" : "empty";
  const clickable = day !== null && !isDisabled;

  return (
    <S.Cell
      type="button"
      disabled={!clickable}
      $variant={variant}
      $color={variant === "filled" ? color : null}
      $selected={selected}
      $clickable={clickable}
      $disabled={isDisabled}
      onClick={clickable ? onClick : undefined}
    />
  );
}

```

## 화면 구성

| 나의 정원 월별 조회 | 나의 정원 일별 조회 |
|---|---|
| <img width="672" height="662" alt="스크린샷 2026-03-23 오후 6 27 53" src="https://github.com/user-attachments/assets/146c82c0-9fad-48e8-b349-1a230a7b7f11" /> | <img width="671" height="660" alt="스크린샷 2026-03-23 오후 6 28 12" src="https://github.com/user-attachments/assets/dd1544a1-8804-4697-813f-ab2cb0ccb75c" /> | 


## Check List

- [x] 코드가 정상적으로 동작함
- [x] 기존 기능에 영향을 주지 않음
- [x] 린트/포맷팅 적용 완료
- [ ] 관련 테스트 작성 또는 기존 테스트 통과 확인
- [x] 리뷰어가 이해할 수 있도록 충분한 설명이 포함됨

## 이슈

- close #7
